### PR TITLE
equal validator boolean / number support (ValentinK)

### DIFF
--- a/src/custom-validators.ts
+++ b/src/custom-validators.ts
@@ -2,6 +2,8 @@ import { ValidatorFn, AbstractControl, Validators } from '@angular/forms';
 
 import { isPresent, isString } from './lang';
 
+export type EqualValueType = string | boolean | number;
+
 export class CustomValidators {
     /**
      * Validator that requires controls to have a value of a range length.
@@ -239,7 +241,7 @@ export class CustomValidators {
     /**
      * Validator that requires controls to have a value to equal another value.
      */
-    static equal(str: string): ValidatorFn {
+    static equal(str: EqualValueType): ValidatorFn {
         return (control: AbstractControl): {[key: string]: any} => {
             if (isPresent(Validators.required(control))) return null;
 

--- a/src/directives/equal.ts
+++ b/src/directives/equal.ts
@@ -2,6 +2,7 @@ import { Directive, Input, forwardRef, OnInit } from '@angular/core';
 import { NG_VALIDATORS, Validator, ValidatorFn, AbstractControl } from '@angular/forms';
 
 import { CustomValidators } from '../';
+import { EqualValueType } from '../custom-validators';
 
 const EQUAL_VALIDATOR: any = {
     provide: NG_VALIDATORS,
@@ -14,7 +15,7 @@ const EQUAL_VALIDATOR: any = {
     providers: [EQUAL_VALIDATOR]
 })
 export class EqualValidator implements Validator, OnInit {
-    @Input() equal: string;
+    @Input() equal: EqualValueType;
 
     private validator: ValidatorFn;
 

--- a/src/specs/custom-validators.spec.ts
+++ b/src/specs/custom-validators.spec.ts
@@ -199,7 +199,7 @@ describe('Custom Validators Email,', () => {
     });
 });
 
-describe('Custom Validators Equal,', () => {
+describe('Custom Validators Equal (string),', () => {
     let control: FormControl;
     let validator: ValidatorFn;
 
@@ -214,6 +214,25 @@ describe('Custom Validators Equal,', () => {
 
     it('"yyy" should equal to "{equal: true}"', () => {
         control = new FormControl('yyy');
+        expect(validator(control)).toEqual({equal: true});
+    });
+});
+
+describe('Custom Validators Equal (boolean),', () => {
+    let control: FormControl;
+    let validator: ValidatorFn;
+
+    beforeEach(() => {
+        validator = CustomValidators.equal(true);
+    });
+
+    it('"xxx" should equal to "null"', () => {
+        control = new FormControl(true);
+        expect(validator(control)).toBeNull()
+    });
+
+    it('"yyy" should equal to "{equal: true}"', () => {
+        control = new FormControl(false);
         expect(validator(control)).toEqual({equal: true});
     });
 });


### PR DESCRIPTION
For now, using equal validator with checkboxes is not useful, because typescript expect string, instead of boolean. With this fix it will works well.
PS: check and run tests before merge (if you will merge it).
