### PR TITLE
Fix: Add registerOnValidatorChange method so that validation is re-triggered 

### DIFF
--- a/src/directives/equal.ts
+++ b/src/directives/equal.ts
@@ -17,6 +17,7 @@ export class EqualValidator implements Validator, OnInit, OnChanges {
   @Input() equal: any;
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.equal(this.equal);
@@ -26,11 +27,16 @@ export class EqualValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'equal') {
         this.validator = CustomValidators.equal(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/max-date.ts
+++ b/src/directives/max-date.ts
@@ -17,6 +17,7 @@ export class MaxDateValidator implements Validator, OnInit, OnChanges {
   @Input() maxDate;
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.maxDate(this.maxDate);
@@ -26,11 +27,16 @@ export class MaxDateValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'maxDate') {
         this.validator = CustomValidators.maxDate(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/max.ts
+++ b/src/directives/max.ts
@@ -17,6 +17,7 @@ export class MaxValidator implements Validator, OnInit, OnChanges {
   @Input() max: number;
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.max(this.max);
@@ -26,11 +27,16 @@ export class MaxValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'max') {
         this.validator = CustomValidators.max(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/min-date.ts
+++ b/src/directives/min-date.ts
@@ -17,6 +17,7 @@ export class MinDateValidator implements Validator, OnInit, OnChanges {
   @Input() minDate;
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.minDate(this.minDate);
@@ -26,11 +27,16 @@ export class MinDateValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'minDate') {
         this.validator = CustomValidators.minDate(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/min.ts
+++ b/src/directives/min.ts
@@ -17,6 +17,7 @@ export class MinValidator implements Validator, OnInit, OnChanges {
   @Input() min: number;
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.min(this.min);
@@ -26,11 +27,16 @@ export class MinValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'min') {
         this.validator = CustomValidators.min(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/phone.ts
+++ b/src/directives/phone.ts
@@ -17,6 +17,7 @@ export class PhoneValidator implements Validator, OnInit, OnChanges {
   @Input() phone: string;
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.phone(this.phone);
@@ -26,11 +27,16 @@ export class PhoneValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'phone') {
         this.validator = CustomValidators.phone(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/range-length.ts
+++ b/src/directives/range-length.ts
@@ -17,6 +17,7 @@ export class RangeLengthValidator implements Validator, OnInit, OnChanges {
   @Input() rangeLength: [number];
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.rangeLength(this.rangeLength);
@@ -26,11 +27,16 @@ export class RangeLengthValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'rangeLength') {
         this.validator = CustomValidators.rangeLength(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/range.ts
+++ b/src/directives/range.ts
@@ -17,6 +17,7 @@ export class RangeValidator implements Validator, OnInit, OnChanges {
   @Input() range: [number];
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.range(this.range);
@@ -26,11 +27,16 @@ export class RangeValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'range') {
         this.validator = CustomValidators.range(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }

--- a/src/directives/uuid.ts
+++ b/src/directives/uuid.ts
@@ -17,6 +17,7 @@ export class UUIDValidator implements Validator, OnInit, OnChanges {
   @Input() uuid;
 
   private validator: ValidatorFn;
+  private _onChange: () => void;
 
   ngOnInit() {
     this.validator = CustomValidators.uuid(this.uuid);
@@ -26,11 +27,16 @@ export class UUIDValidator implements Validator, OnInit, OnChanges {
     for (let key in changes) {
       if (key === 'uuid') {
         this.validator = CustomValidators.uuid(changes[key].currentValue);
+        if (this._onChange) this._onChange();
       }
     }
   }
 
   validate(c: AbstractControl): {[key: string]: any} {
     return this.validator(c);
+  }
+
+  registerOnValidatorChange(fn: () => void): void {
+    this._onChange = fn;
   }
 }


### PR DESCRIPTION
Fix: Add registerOnValidatorChange method so that validation is re-triggered when the value being validated against changes.

For example, if the max value is 5, and the input field's value is 4, and then max changes to 3, the input field should show a max value error