### PR TITLE
min and max validators should ignore date values instead of trying to typecast them into numbers and getting NaN, causing validation to fail

### DIFF
--- a/src/max/validator.spec.ts
+++ b/src/max/validator.spec.ts
@@ -22,4 +22,9 @@ describe('Max', () => {
 
     expect(max(5)(control)).toEqual(error);
   });
+
+  it('should ignore date-time values', () => {
+    let control = new FormControl('2016-09-08');
+    expect(max(<any>'2016-09-09')(control)).toBeNull();
+  });
 });

--- a/src/max/validator.ts
+++ b/src/max/validator.ts
@@ -1,11 +1,12 @@
 import { AbstractControl, Validators, ValidatorFn } from '@angular/forms';
 
-import { isPresent } from '../facade/lang';
+import { isPresent, isDate } from '../facade/lang';
 
 export const max = (max: number): ValidatorFn => {
   return (control: AbstractControl): {[key: string]: boolean} => {
     if (!isPresent(max)) return null;
     if (isPresent(Validators.required(control))) return null;
+    if (isNaN(max) && isDate(new Date(max))) return null;
 
     let v: number = +control.value;
     return v <= +max ? null : {max: true};

--- a/src/min/validator.spec.ts
+++ b/src/min/validator.spec.ts
@@ -16,4 +16,9 @@ describe('Min', () => {
 
     expect(min(10)(control)).toEqual(error);
   });
+
+  it('should ignore date-time values', () => {
+    let control = new FormControl('2016-09-10');
+    expect(min(<any>'2016-09-09')(control)).toBeNull();
+  });
 });

--- a/src/min/validator.ts
+++ b/src/min/validator.ts
@@ -1,11 +1,12 @@
 import { AbstractControl, Validators, ValidatorFn } from '@angular/forms';
 
-import { isPresent } from '../facade/lang';
+import { isPresent, isDate } from '../facade/lang';
 
 export const min = (min: number): ValidatorFn => {
   return (control: AbstractControl): {[key: string]: boolean} => {
     if (!isPresent(min)) return null;
     if (isPresent(Validators.required(control))) return null;
+    if (isNaN(min) && isDate(new Date(min))) return null;
 
     let v: number = +control.value;
     return v >= +min ? null : {min: true};


### PR DESCRIPTION
According to MDN at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input, min and max can take a date-time value.

My use case is I have an input field with the HTML:

```
                        <input type="date"
                            id="calculationDate"
                            class="form-control"
                            name="calculationDate"
                            min="1900-01-01"
                            minDate="1900-01-01"
                            max="2099-12-31"
                            maxDate="2099-12-31"
                            [(ngModel)]="model.calculationDate"
                            #calculationDate="ngModel"
                            required
                            date/>
```
I use min and max so that when chrome displays its built-in calendar widget, dates before min and after max are grayed out / unselectable.

However, when I have this HTML, the min and max validators end up trying to convert these values into a number, which results in NaN, which causes the validation to fail.

To fix this issue, if the min or max value isNaN and is a date, then simply return null. The validtion of these fields are handled by minDate and maxDate